### PR TITLE
Add flag to accept insecure certificates

### DIFF
--- a/lib/cli_options.rb
+++ b/lib/cli_options.rb
@@ -7,6 +7,7 @@ require 'optparse'
   update: false,
   update_all: false,
   list_versions: false,
+  verify_host: 2,
   timeout: 20,
   connecttimeout: 5,
   user_agent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0'
@@ -15,6 +16,10 @@ require 'optparse'
 OptionParser.new('Usage: ./fingerprinter.rb [options]', 50) do |opts|
   opts.on('--proxy PROXY', '-p', 'Proxy to use during the fingerprinting') do |proxy|
     @options[:proxy] = proxy
+  end
+
+  opts.on('--insecure', '-k', 'Disable certificate verification when negotiating TLS/SSL connections') do
+    @options[:verify_host] = 0
   end
 
   opts.on('--timeout SECONDS', 'The number of seconds for the requests to be performed, default 20s') do |timeout|

--- a/lib/cli_options.rb
+++ b/lib/cli_options.rb
@@ -7,7 +7,6 @@ require 'optparse'
   update: false,
   update_all: false,
   list_versions: false,
-  verify_host: 2,
   timeout: 20,
   connecttimeout: 5,
   user_agent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0'
@@ -16,10 +15,6 @@ require 'optparse'
 OptionParser.new('Usage: ./fingerprinter.rb [options]', 50) do |opts|
   opts.on('--proxy PROXY', '-p', 'Proxy to use during the fingerprinting') do |proxy|
     @options[:proxy] = proxy
-  end
-
-  opts.on('--insecure', '-k', 'Disable certificate verification when negotiating TLS/SSL connections') do
-    @options[:verify_host] = 0
   end
 
   opts.on('--timeout SECONDS', 'The number of seconds for the requests to be performed, default 20s') do |timeout|

--- a/lib/fingerprinter.rb
+++ b/lib/fingerprinter.rb
@@ -53,10 +53,6 @@ class Fingerprinter
     @options[:proxy]
   end
 
-  def verify_host
-    @options[:verify_host]
-  end
-
   def cookies_file
     @options[:cookies_file]
   end
@@ -77,7 +73,7 @@ class Fingerprinter
     opts = {
       proxy: proxy,
       ssl_verifypeer: false,
-      ssl_verifyhost: verify_host,
+      ssl_verifyhost: 2,
       cookie: cookies_string,
       timeout: timeout,
       connecttimeout: connect_timeout

--- a/lib/fingerprinter.rb
+++ b/lib/fingerprinter.rb
@@ -53,6 +53,10 @@ class Fingerprinter
     @options[:proxy]
   end
 
+  def verify_host
+    @options[:verify_host]
+  end
+
   def cookies_file
     @options[:cookies_file]
   end
@@ -73,7 +77,7 @@ class Fingerprinter
     opts = {
       proxy: proxy,
       ssl_verifypeer: false,
-      ssl_verifyhost: 2,
+      ssl_verifyhost: verify_host,
       cookie: cookies_string,
       timeout: timeout,
       connecttimeout: connect_timeout

--- a/lib/fingerprinter.rb
+++ b/lib/fingerprinter.rb
@@ -73,7 +73,7 @@ class Fingerprinter
     opts = {
       proxy: proxy,
       ssl_verifypeer: false,
-      ssl_verifyhost: 2,
+      ssl_verifyhost: 0,
       cookie: cookies_string,
       timeout: timeout,
       connecttimeout: connect_timeout


### PR DESCRIPTION
Sometimes a website have expired/miss-configured/self-signed certificates and when trying to fingerprint a site, this error is shown: `SSL peer certificate or SSH remote key was not OK`

It would be useful to have an option to allow invalid certificates, similar to the `-k` flag that curl has.
This pr adds this new option, let me know if: (1) Do you agree to add this feature (2) you are ok with the way I did the changes (3) or you want to do it in a different way or make some changes to the PR.

(By the way, curl itself does almost the same way I did: https://github.com/curl/curl/blob/8c1cc369d0c7163c6dcc91fd38edfea1f509ae75/src/tool_operate.c#L1153)

Thank you again for accepting issues so fast! Also I like this tool a lot.