### PR TITLE
lax cms_scanner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'bundler', '>= 1.6'
-gem 'cms_scanner', '~> 0.13.0'
+gem 'cms_scanner', '~> 0.13'
 gem 'dearchiver', '~> 0.0'
 gem 'json', '~> 2.5'


### PR DESCRIPTION
instead of locking cms_scanner to 0.13.9 this will allow to use cms_scanner 0.15.0 and so to get Ruby 3.4 support